### PR TITLE
Update Amazon IVS Player SDK to 1.16.0

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -1,5 +1,5 @@
 platform :ios, '14.0'
 
 target 'amazon-ivs-optimizations-ios-demo' do
-    pod 'AmazonIVSPlayer', '~> 1.14.0'
+    pod 'AmazonIVSPlayer', '~> 1.16.0'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,16 +1,16 @@
 PODS:
-  - AmazonIVSPlayer (1.14.0)
+  - AmazonIVSPlayer (1.16.0)
 
 DEPENDENCIES:
-  - AmazonIVSPlayer (~> 1.14.0)
+  - AmazonIVSPlayer (~> 1.16.0)
 
 SPEC REPOS:
   trunk:
     - AmazonIVSPlayer
 
 SPEC CHECKSUMS:
-  AmazonIVSPlayer: afa368571fe046e99900c88ef891755e01f44bc5
+  AmazonIVSPlayer: e9092086094e70ba1e39b3f6f57f623da05b4b27
 
-PODFILE CHECKSUM: 1d189fe292555ed78cf25a2468ffc77827de5756
+PODFILE CHECKSUM: 9dcdd623ba38a9d85307ce27f997c86a6d7bb5a3
 
 COCOAPODS: 1.11.3


### PR DESCRIPTION
Update Amazon IVS Player SDK to 1.16.0

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
